### PR TITLE
feat: BaseTimeEntity 생성 및 전체적용 - createdDate, modifiedDate 일괄 추가

### DIFF
--- a/src/main/java/com/depromeet/fairer/Application.java
+++ b/src/main/java/com/depromeet/fairer/Application.java
@@ -2,7 +2,9 @@ package com.depromeet.fairer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
 

--- a/src/main/java/com/depromeet/fairer/domain/assignment/Assignment.java
+++ b/src/main/java/com/depromeet/fairer/domain/assignment/Assignment.java
@@ -1,5 +1,6 @@
 package com.depromeet.fairer.domain.assignment;
 
+import com.depromeet.fairer.domain.base.BaseTimeEntity;
 import com.depromeet.fairer.domain.housework.HouseWork;
 import com.depromeet.fairer.domain.member.Member;
 import lombok.*;
@@ -13,7 +14,7 @@ import javax.persistence.*;
 @Builder
 @ToString(exclude = {"member","houseWork"})
 @AllArgsConstructor @NoArgsConstructor
-public class Assignment {
+public class Assignment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/depromeet/fairer/domain/base/BaseTimeEntity.java
+++ b/src/main/java/com/depromeet/fairer/domain/base/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.depromeet.fairer.domain.base;
+
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Data
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/depromeet/fairer/domain/housework/HouseWork.java
+++ b/src/main/java/com/depromeet/fairer/domain/housework/HouseWork.java
@@ -1,6 +1,7 @@
 package com.depromeet.fairer.domain.housework;
 
 import com.depromeet.fairer.domain.assignment.Assignment;
+import com.depromeet.fairer.domain.base.BaseTimeEntity;
 import com.depromeet.fairer.domain.preset.constant.Space;
 import com.depromeet.fairer.domain.team.Team;
 import lombok.*;
@@ -19,7 +20,7 @@ import java.util.List;
 @EqualsAndHashCode
 @Builder
 @NoArgsConstructor @AllArgsConstructor
-public class HouseWork {
+public class HouseWork extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "housework_id", columnDefinition = "BIGINT", nullable = false, unique = true)

--- a/src/main/java/com/depromeet/fairer/domain/member/Member.java
+++ b/src/main/java/com/depromeet/fairer/domain/member/Member.java
@@ -1,5 +1,6 @@
 package com.depromeet.fairer.domain.member;
 
+import com.depromeet.fairer.domain.base.BaseTimeEntity;
 import com.depromeet.fairer.dto.member.oauth.OAuthAttributes;
 import com.depromeet.fairer.domain.assignment.Assignment;
 import com.depromeet.fairer.domain.memberToken.MemberToken;
@@ -19,7 +20,7 @@ import java.util.List;
 @ToString(exclude = {"team", "assignments"})
 @Builder
 @AllArgsConstructor @NoArgsConstructor
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/depromeet/fairer/domain/memberToken/MemberToken.java
+++ b/src/main/java/com/depromeet/fairer/domain/memberToken/MemberToken.java
@@ -1,5 +1,6 @@
 package com.depromeet.fairer.domain.memberToken;
 
+import com.depromeet.fairer.domain.base.BaseTimeEntity;
 import com.depromeet.fairer.domain.member.Member;
 import com.depromeet.fairer.domain.memberToken.constant.RemainingTokenTime;
 import lombok.*;
@@ -13,7 +14,7 @@ import java.time.temporal.ChronoUnit;
 @Getter
 @Builder
 @AllArgsConstructor @NoArgsConstructor
-public class MemberToken {
+public class MemberToken extends BaseTimeEntity {
 
     @Id
     @Column(name = "member_token_id")

--- a/src/main/java/com/depromeet/fairer/domain/preset/Preset.java
+++ b/src/main/java/com/depromeet/fairer/domain/preset/Preset.java
@@ -1,5 +1,6 @@
 package com.depromeet.fairer.domain.preset;
 
+import com.depromeet.fairer.domain.base.BaseTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 @Setter
 @Builder
 @NoArgsConstructor @AllArgsConstructor
-public class Preset {
+public class Preset extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "preset_id", columnDefinition = "BIGINT", nullable = false, unique = true)

--- a/src/main/java/com/depromeet/fairer/domain/team/Team.java
+++ b/src/main/java/com/depromeet/fairer/domain/team/Team.java
@@ -1,5 +1,6 @@
 package com.depromeet.fairer.domain.team;
 
+import com.depromeet.fairer.domain.base.BaseTimeEntity;
 import com.depromeet.fairer.domain.housework.HouseWork;
 import com.depromeet.fairer.domain.member.Member;
 import lombok.*;
@@ -18,7 +19,7 @@ import java.util.Set;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Team {
+public class Team extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
@dskym @daeunkwak @SDB016 BaseTimeEntity 만들어서 추가해보았는데 리뷰해주시면 감사하겠습니다 :) 


실행될 SQL문

```
alter table assignment 
       add column created_date datetime(6)
Hibernate: 
    
    alter table assignment 
       add column modified_date datetime(6)
Hibernate: 
    
    alter table housework 
       add column created_date datetime(6)
Hibernate: 
    
    alter table housework 
       add column modified_date datetime(6)
Hibernate: 
    
    alter table member 
       add column created_date datetime(6)
Hibernate: 
    
    alter table member 
       add column modified_date datetime(6)
Hibernate: 
    
    alter table member_token 
       add column created_date datetime(6)
Hibernate: 
    
    alter table member_token 
       add column modified_date datetime(6)
Hibernate: 
    
    alter table preset 
       add column created_date datetime(6)
Hibernate: 
    
    alter table preset 
       add column modified_date datetime(6)
Hibernate: 
    
    alter table team 
       add column created_date datetime(6)
Hibernate: 
    
    alter table team 
       add column modified_date datetime(6)
```

### 참고
- fairer_dev 스키마에 변경사항 적용되지 않아서 ci 실패합니다. 리뷰 후 스키마 업데이트 진행 예정이니 참고해주세요!