### PR TITLE
feat: 로그인&회원가입 api에 팀 소속 여부 반환 필드 추가

### DIFF
--- a/src/main/java/com/depromeet/fairer/dto/member/jwt/ResponseJwtTokenDto.java
+++ b/src/main/java/com/depromeet/fairer/dto/member/jwt/ResponseJwtTokenDto.java
@@ -28,4 +28,7 @@ public class ResponseJwtTokenDto {
 
     @ApiModelProperty(value = "신규 회원 여부")
     private Boolean isNewMember = false;
+
+    @ApiModelProperty(value = "팀 소속 여부")
+    private Boolean hasTeam = false;
 }

--- a/src/main/java/com/depromeet/fairer/repository/member/MemberRepository.java
+++ b/src/main/java/com/depromeet/fairer/repository/member/MemberRepository.java
@@ -12,5 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     Optional<Member> findByEmail(String email);
 
     @EntityGraph(attributePaths = {"team"})
+    Optional<Member> findWithTeamByEmail(String email);
+
+    @EntityGraph(attributePaths = {"team"})
     Optional<Member> findWithTeamByMemberId(Long memberId);
 }

--- a/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
+++ b/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
@@ -43,13 +43,19 @@ public class OauthLoginService {
 
         // 회원 가입 or 로그인
         Boolean isNewMember = false;
+        Boolean hasTeam = false;
         Member requestMember;
-        final Optional<Member> foundMember = memberRepository.findByEmail(socialUserInfo.getEmail());
+        final Optional<Member> foundMember = memberRepository.findWithTeamByEmail(socialUserInfo.getEmail());
         if (foundMember.isEmpty()) { // 기존 회원 아닐 때
             Member newMember = Member.create(socialUserInfo);
             requestMember = memberRepository.save(newMember);
             isNewMember = true;
-        } else requestMember = foundMember.get(); // 기존 회원일 때
+        } else {
+            requestMember = foundMember.get(); // 기존 회원일 때
+            if (requestMember.getTeam() != null) {
+                hasTeam = true;
+            }
+        }
 
         // JWT 토큰 생성
         TokenDto tokenDto = tokenProvider.createTokenDto(requestMember.getMemberId());
@@ -57,6 +63,7 @@ public class OauthLoginService {
 
         ResponseJwtTokenDto responseJwtTokenDto = modelMapper.map(tokenDto, ResponseJwtTokenDto.class);
         responseJwtTokenDto.setIsNewMember(isNewMember);
+        responseJwtTokenDto.setHasTeam(hasTeam);
 
         return responseJwtTokenDto;
     }


### PR DESCRIPTION
안드로이드에서 로그인(회원가입) api 호출시 
응답으로 소속한 팀이 있는지 여부 필드 추가해달라고 해서 추가했습니다.