### PR TITLE
fix: 집안일 반복 기능 적용 API 수정

### DIFF
--- a/fairer-api/src/main/java/com/depromeet/fairer/api/HouseWorkController.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/api/HouseWorkController.java
@@ -156,6 +156,7 @@ public class HouseWorkController {
         return ResponseEntity.ok(houseWorkService.getHouseWorkDetail(houseWorkId));
     }
 
+    @Deprecated
     @Tag(name = "houseWorks")
     @GetMapping("/success/count")
     public ResponseEntity<HouseWorkSuccessCountResponseDto> getSuccessCount(@RequestParam String scheduledDate,

--- a/fairer-api/src/main/java/com/depromeet/fairer/domain/housework/HouseWork.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/domain/housework/HouseWork.java
@@ -9,14 +9,13 @@ import com.depromeet.fairer.domain.repeatexception.RepeatException;
 import com.depromeet.fairer.domain.team.Team;
 import com.depromeet.fairer.global.util.DateTimeUtils;
 import lombok.*;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
-
-import static com.fasterxml.jackson.databind.type.LogicalType.valueOf;
 
 @Entity
 @Table(name = "housework")
@@ -82,7 +81,7 @@ public class HouseWork extends BaseTimeEntity {
         }
         boolean result = true;
         if (repeatCycle == RepeatCycle.WEEKLY) {
-            result = repeatPattern.contains(DateTimeUtils.convertDayOfWeekToEng(date.getDayOfWeek()));
+            result = StringUtils.containsIgnoreCase(repeatPattern, DateTimeUtils.convertDayOfWeekToEng(date.getDayOfWeek()));
         } else if (repeatCycle == RepeatCycle.MONTHLY) {
             result = Integer.parseInt(repeatPattern) == date.getDayOfMonth();
         } /*else if (repeatCycle == RepeatCycle.DAILY) {

--- a/fairer-api/src/main/java/com/depromeet/fairer/dto/housework/request/HouseWorkUpdateRequestDto.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/dto/housework/request/HouseWorkUpdateRequestDto.java
@@ -57,13 +57,13 @@ public class HouseWorkUpdateRequestDto {
     @JsonDeserialize(using = LocalDateDeserializer.class)
     private LocalDate repeatEndDate;
 
-    @ApiModelProperty(value = "삭제할 집안일 기간", required = true, example = "단일 삭제: 'O' / 앞으로 삭제: 'H' / 모두 삭제: 'A'")
+    @ApiModelProperty(value = "수정할 집안일 기간", required = true, example = "단일 수정: 'O' / 앞으로 일정 수정: 'H' / 모두 수정: 'A'")
     @NotNull
     private String type;
 
-    @ApiModelProperty(value = "삭제 기준 날짜", example = "2022-07-02",
-            notes = "주기에 해당하는 날짜여야 함, 수요일 주기일 경우 삭제의 기준이 되는 원하는 마지막 수요일 날짜")
+    @ApiModelProperty(value = "수정 기준 날짜", example = "2022-07-02",
+            notes = "주기에 해당하는 날짜여야 함, 수요일 주기일 경우 수정의 기준이 되는 원하는 마지막 수요일 날짜")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonDeserialize(using = LocalDateDeserializer.class)
-    private LocalDate deleteStandardDate;
+    private LocalDate updateStandardDate;
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/dto/housework/request/HouseWorksCreateRequestDto.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/dto/housework/request/HouseWorksCreateRequestDto.java
@@ -57,6 +57,7 @@ public class HouseWorksCreateRequestDto {
                 .scheduledTime(scheduledTime)
                 .repeatPattern(repeatPattern)
                 .repeatCycle(RepeatCycle.of(repeatCycle))
+                .repeatEndDate(null)
                 .success(false)
                 .successDateTime(null)
                 .build();

--- a/fairer-api/src/main/java/com/depromeet/fairer/dto/housework/response/HouseWorkResponseDto.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/dto/housework/response/HouseWorkResponseDto.java
@@ -61,8 +61,7 @@ public class HouseWorkResponseDto {
     @ApiModelProperty(value = "집안일 반복 요일", example = "repeatCycle이 weekly일 경우: monday, sunday / monthly일 경우: 31")
     private String repeatPattern;
 
-    @ApiModelProperty(value = "집안일 종료일", example = "2022-07-02", required = true)
-    @NotNull
+    @ApiModelProperty(value = "집안일 종료일", example = "2022-07-02")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonDeserialize(using = LocalDateDeserializer.class)
     private LocalDate repeatEndDate;

--- a/fairer-api/src/main/java/com/depromeet/fairer/global/config/interceptor/AuthInterceptor.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/global/config/interceptor/AuthInterceptor.java
@@ -16,7 +16,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Date;

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/assignment/AssignmentService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/assignment/AssignmentService.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Slf4j

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/MemberService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/MemberService.java
@@ -3,14 +3,13 @@ package com.depromeet.fairer.service.member;
 import com.depromeet.fairer.domain.team.Team;
 import com.depromeet.fairer.domain.member.Member;
 
-import com.depromeet.fairer.global.exception.BadRequestException;
 import com.depromeet.fairer.global.exception.NoSuchMemberException;
 
 import com.depromeet.fairer.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.security.InvalidParameterException;
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/google/GoogleFeignService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/google/GoogleFeignService.java
@@ -14,7 +14,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.Map;
 import java.util.Objects;
 

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/team/TeamService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/team/TeamService.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;


### PR DESCRIPTION
집안일 추가 API
- Repeat pattern에 대한 validation 체크 추가

집안일 완료 개수 API
- 미사용으로 보여서 deprecated

특정 팀원 집안일 조회 API
- ONCE의 경우 팀 조건이 없어서 다른 팀 집안일도 같이 조회되는 버그 수정
- 쿼리 정리

특정 기간 집안일 조회 API
- ONCE의 경우 멤버 조건이 없어서 다른 멤버 집안일도 같이 조회되는 버그 수정
- 쿼리 정리

집안일 수정 API
- repeat end date 기준일 전날로 세팅하도록 수정
- 오타 수정

집안일 삭제 API
- 매주 반복 집안일 삭제할 때 기준일이 포함 되어 있는지 요일 비교할 때 대소문자 구분해서 비교 하는거 수정

기타
- spring에서 지원하는 transactional 어노테이션 사용하도록 수정