### PR TITLE
feat: 회원 탈퇴 api 구현

### DIFF
--- a/fairer-api/src/main/java/com/depromeet/fairer/api/OauthLoginController.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/api/OauthLoginController.java
@@ -5,18 +5,18 @@ import com.depromeet.fairer.dto.member.oauth.OauthRequestDto;
 import com.depromeet.fairer.dto.member.jwt.ResponseJwtTokenDto;
 import com.depromeet.fairer.domain.member.constant.SocialType;
 import com.depromeet.fairer.global.exception.BadRequestException;
+import com.depromeet.fairer.global.resolver.RequestMemberId;
 import com.depromeet.fairer.service.member.oauth.OauthLoginService;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.EnumUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -86,5 +86,18 @@ public class OauthLoginController {
     public ResponseEntity<String> logout(@RequestHeader(value = "Authorization") String refreshToken) {
         oauthLoginService.logout(refreshToken, LocalDateTime.now());
         return ResponseEntity.ok().body("로그아웃이 완료되었습니다.");
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+
+    @Tag(name = "oauth")
+    @PostMapping(value = "/signout")
+    @Operation(summary = "회원 탈퇴", description = "토큰에 해당하는 멤버의 refresh token 만료 처리")
+    public ResponseEntity<String> signOut(@ApiIgnore @RequestMemberId Long memberId) {
+
+        oauthLoginService.signOut(memberId);
+        return ResponseEntity.ok().body("회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/domain/member/Member.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/domain/member/Member.java
@@ -7,6 +7,8 @@ import com.depromeet.fairer.domain.team.Team;
 import com.depromeet.fairer.domain.member.constant.SocialType;
 import com.depromeet.fairer.global.exception.CannotJoinTeamException;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -28,6 +30,8 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE member_id = ?")
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -63,6 +67,9 @@ public class Member extends BaseTimeEntity {
 
     @Column(name = "fcm_token_date", columnDefinition = "DATETIME")
     private LocalDateTime fcmTokenDate;
+
+    @Column(name = "deleted_at", columnDefinition = "DATETIME")
+    private LocalDateTime deletedAt;
 
     /**
      * TODO 닉네임 동의 안했을 때 처리 (입력한 닉네임으로 변경)

--- a/fairer-api/src/main/java/com/depromeet/fairer/domain/memberToken/MemberToken.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/domain/memberToken/MemberToken.java
@@ -1,6 +1,7 @@
 package com.depromeet.fairer.domain.memberToken;
 
 import com.depromeet.fairer.domain.base.BaseTimeEntity;
+import com.depromeet.fairer.domain.member.Member;
 import com.depromeet.fairer.domain.memberToken.constant.RemainingTokenTime;
 import lombok.*;
 
@@ -20,14 +21,20 @@ public class MemberToken extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long memberTokenId;
 
+    @Column(name = "refresh_token", columnDefinition = "VARCHAR(255)", unique = true)
     private String refreshToken;
 
+    @Column(name = "token_expiration_time", columnDefinition = "DATETIME")
     private LocalDateTime tokenExpirationTime;
 
-    public static MemberToken create(String refreshToken, LocalDateTime tokenExpiredTime) {
+    @Column(name = "member_id", columnDefinition = "BIGINT")
+    private Long memberId;
+
+    public static MemberToken create(String refreshToken, LocalDateTime tokenExpiredTime, Long memberId) {
         final MemberToken memberToken = MemberToken.builder()
                 .refreshToken(refreshToken)
                 .tokenExpirationTime(tokenExpiredTime)
+                .memberId(memberId)
                 .build();
 
         return memberToken;

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/memberToken/MemberTokenCustomRepository.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/memberToken/MemberTokenCustomRepository.java
@@ -1,0 +1,8 @@
+package com.depromeet.fairer.repository.memberToken;
+
+import java.time.LocalDateTime;
+
+public interface MemberTokenCustomRepository {
+
+    void updateExpirationTimeByMemberId(Long memberId, LocalDateTime expirationTime);
+}

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/memberToken/MemberTokenCustomRepositoryImpl.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/memberToken/MemberTokenCustomRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.depromeet.fairer.repository.memberToken;
+
+import com.depromeet.fairer.domain.memberToken.QMemberToken;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Repository
+public class MemberTokenCustomRepositoryImpl implements MemberTokenCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public void updateExpirationTimeByMemberId(Long memberId, LocalDateTime expirationTime) {
+        jpaQueryFactory.update(QMemberToken.memberToken)
+                .where(QMemberToken.memberToken.memberId.eq(memberId))
+                .set(QMemberToken.memberToken.tokenExpirationTime, expirationTime)
+                .execute();
+    }
+}

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/memberToken/MemberTokenRepository.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/memberToken/MemberTokenRepository.java
@@ -4,9 +4,12 @@ import com.depromeet.fairer.domain.memberToken.MemberToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
-public interface MemberTokenRepository extends JpaRepository<MemberToken, Long> {
+public interface MemberTokenRepository extends JpaRepository<MemberToken, Long>, MemberTokenCustomRepository {
     Optional<MemberToken> findByRefreshToken(String refreshToken);
+
+    void updateExpirationTimeByMemberId(Long memberId, LocalDateTime expirationTime);
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/jwt/TokenProvider.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/jwt/TokenProvider.java
@@ -63,7 +63,7 @@ public class TokenProvider {
         String accessToken = createAccessToken(memberId, accessTokenExpireTime);
         String refreshToken = createRefreshToken(memberId, refreshTokenExpireTime);
 
-        final MemberToken memberToken = MemberToken.create(refreshToken, DateTimeUtils.convertToLocalDateTime(refreshTokenExpireTime));
+        final MemberToken memberToken = MemberToken.create(refreshToken, DateTimeUtils.convertToLocalDateTime(refreshTokenExpireTime), memberId);
         memberTokenRepository.save(memberToken);
 
         return TokenDto.builder()

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
@@ -365,8 +365,7 @@ public class OauthLoginService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoSuchMemberException("해당 멤버가 존재하지 않습니다."));
 
-        member.setDeletedAt(LocalDateTime.now());
-        memberRepository.save(member);
+        memberRepository.delete(member);
 
         memberTokenRepository.updateExpirationTimeByMemberId(memberId, LocalDateTime.now());
     }


### PR DESCRIPTION
* [memberdp soft delete 설정](https://github.com/depromeet/fairer-be/compare/feature/sign-out?expand=1#diff-e91add284ea46f4706a6a1c28046944118c2b156ff203a10b6db911aec4741f7R34) 추가
* [memberToken엔티티에 memberId 추가](https://github.com/depromeet/fairer-be/compare/feature/sign-out?expand=1#diff-75b14600d81a399b91d640fc69bd1b0024971385129568e5d9300e2c21d787edR30)(원래 DB에는 있었지만 엔티티에는 없었음)
* [memberToken ExpireDate 수정 로직](https://github.com/depromeet/fairer-be/compare/feature/sign-out?expand=1#diff-9b87f1d7db470d684e45295263f4d73f6983ac3c52dcac2184eed40e41a970b5R17)(주로 토큰 만료 시킬 때 사용)