### PR TITLE
feat: 회원탈퇴 soft delete 반영

### DIFF
--- a/fairer-api/build.gradle
+++ b/fairer-api/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa'
 
     // json
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
 
 }
 

--- a/fairer-api/src/main/java/com/depromeet/fairer/domain/member/Member.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/domain/member/Member.java
@@ -7,6 +7,7 @@ import com.depromeet.fairer.domain.team.Team;
 import com.depromeet.fairer.domain.member.constant.SocialType;
 import com.depromeet.fairer.global.exception.CannotJoinTeamException;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -108,5 +109,13 @@ public class Member extends BaseTimeEntity {
         this.memberName = memberName;
         this.profilePath = profilePath;
         this.statusMessage = statusMessage;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/dto/member/MemberDto.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/dto/member/MemberDto.java
@@ -23,10 +23,12 @@ public class MemberDto {
     private String profilePath;
 
     public static MemberDto from(Member member) {
+        String memberName = member.isDeleted() ? "알 수 없음" : member.getMemberName();
+        String profilePath = member.isDeleted() ? "" : member.getProfilePath();
         return MemberDto.builder()
                 .memberId(member.getMemberId())
-                .memberName(member.getMemberName())
-                .profilePath(member.getProfilePath())
+                .memberName(memberName)
+                .profilePath(profilePath)
                 .build();
     }
 

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/assignment/AssignmentRepository.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/assignment/AssignmentRepository.java
@@ -13,13 +13,17 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
+public interface AssignmentRepository extends JpaRepository<Assignment, Long>, AssignmentRepositoryCustom {
     Optional<Assignment> findByHouseWorkAndMember(HouseWork houseWork, Member member);
     List<Assignment> findAllByHouseWorkAndMemberNotIn(HouseWork houseWork, List<Member> members);
 
     List<Assignment> findAllByMember(Member member);
 
+    List<HouseWork> findAllHouseWorkByAssignmentIdInAndHasOnlyAssignee(List<Long> assignmentIds);
+
     @Modifying(clearAutomatically = true)
     @Query("delete from Assignment a where a.houseWork.houseWorkId = :houseWorkId")
     void deleteAllByHouseworkId(@Param("houseWorkId") Long houseWorkId);
+
+    void deleteAllByMember(Member member);
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/assignment/AssignmentRepositoryCustom.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/assignment/AssignmentRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.depromeet.fairer.repository.assignment;
+
+import com.depromeet.fairer.domain.assignment.Assignment;
+import com.depromeet.fairer.domain.housework.HouseWork;
+import com.depromeet.fairer.domain.member.Member;
+
+import java.util.List;
+
+public interface AssignmentRepositoryCustom {
+
+    void deleteAllByMember(Member member);
+
+    List<HouseWork> findAllHouseWorkByAssignmentIdInAndHasOnlyAssignee(List<Long> assignmentIds);
+
+    List<Assignment> findAllByMember(Member member);
+}

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/assignment/AssignmentRepositoryCustomImpl.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/assignment/AssignmentRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.depromeet.fairer.repository.assignment;
+
+import com.depromeet.fairer.domain.assignment.Assignment;
+import com.depromeet.fairer.domain.housework.HouseWork;
+import com.depromeet.fairer.domain.member.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.depromeet.fairer.domain.assignment.QAssignment.assignment;
+import static com.depromeet.fairer.domain.member.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class AssignmentRepositoryCustomImpl implements AssignmentRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public void deleteAllByMember(Member member) {
+        jpaQueryFactory.delete(assignment)
+                .where(assignment.member.eq(member))
+                .execute();
+    }
+
+    @Override
+    public List<HouseWork> findAllHouseWorkByAssignmentIdInAndHasOnlyAssignee(List<Long> assignmentIds) {
+        return jpaQueryFactory.select(assignment.houseWork)
+                .from(assignment)
+                .where(assignment.assignmentId.in(assignmentIds))
+                .groupBy(assignment.assignmentId)
+                .having(assignment.member.count().eq(1L))
+                .fetch();
+    }
+
+    @Override
+    public List<Assignment> findAllByMember(Member member) {
+        return jpaQueryFactory.selectFrom(assignment)
+                .where(assignment.member.eq(member))
+                .fetch();
+    }
+
+}

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/housework/HouseWorkCustomRepository.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/housework/HouseWorkCustomRepository.java
@@ -14,5 +14,7 @@ public interface HouseWorkCustomRepository {
 
     List<HouseWorkQueryResponseDto> getCycleHouseWorkByTeamQuery(LocalDate date, Team team);
 
+    void updateAllByHouseWorkIdSetRepeatEndDate(List<Long> houseWorkIds, LocalDate date);
+
     List<HouseWork> getCycleHouseWorkByTeamMonth(LocalDate fromDate, LocalDate toDate, Team team);
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/housework/HouseWorkCustomRepositoryImpl.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/housework/HouseWorkCustomRepositoryImpl.java
@@ -86,6 +86,14 @@ public class HouseWorkCustomRepositoryImpl implements HouseWorkCustomRepository 
                 ).fetch();
     }
 
+    @Override
+    public void updateAllByHouseWorkIdSetRepeatEndDate(List<Long> houseWorkIds, LocalDate date) {
+        jpaQueryFactory.update(houseWork)
+                .set(houseWork.repeatEndDate, date)
+                .where(houseWork.houseWorkId.in(houseWorkIds))
+                .execute();
+    }
+
 
     @Override
     public List<HouseWork> getCycleHouseWorkByTeamMonth(LocalDate fromDate, LocalDate toDate, Team team) {

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/housework/HouseWorkRepository.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/housework/HouseWorkRepository.java
@@ -22,7 +22,6 @@ public interface HouseWorkRepository extends JpaRepository<HouseWork, Long>, Hou
     List<HouseWork> findAllByScheduledDateAndAssignmentsIn(LocalDate scheduledDate, List<Assignment> assignments);
     List<HouseWork> findAllByScheduledDateBetweenAndAssignmentsIn(LocalDate fromDate, LocalDate toDate, List<Assignment> assignments);
     List<HouseWork> findAllByScheduledDateBetweenAndTeam(LocalDate fromDate, LocalDate toDate, Team team);
-
     @EntityGraph(attributePaths = {"team"})
     Optional<HouseWork> findWithTeamByHouseWorkId(Long houseWorkId);
 

--- a/fairer-api/src/main/java/com/depromeet/fairer/repository/member/MemberRepository.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/repository/member/MemberRepository.java
@@ -19,4 +19,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     @EntityGraph(attributePaths = {"team"})
     Optional<Member> findWithTeamByMemberId(Long memberId);
 
+    Optional<Member> findByEmail(String email);
+
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
@@ -396,10 +396,6 @@ public class OauthLoginService {
         member.setProfilePath(defaultProfileUrl);
         member.delete();
 
-        memberRepository.findAll();
-
-        System.out.println(houseWorkRepository.findAll().size());
-
         memberTokenRepository.updateExpirationTimeByMemberId(memberId, LocalDateTime.now());
     }
 }

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
@@ -60,6 +60,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
+++ b/fairer-api/src/main/java/com/depromeet/fairer/service/member/oauth/OauthLoginService.java
@@ -390,8 +390,10 @@ public class OauthLoginService {
 
         assignmentRepository.deleteAllByMember(member);
 
-        member.setEmail(member.getEmail() + "_deleted_at_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        String defaultProfileUrl = "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile1.svg?alt=media&token=13ef5688-3e56-452d-9c63-763958427674";
 
+        member.setEmail(member.getEmail() + "_deleted_at_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        member.setProfilePath(defaultProfileUrl);
         member.delete();
 
         memberRepository.findAll();


### PR DESCRIPTION
## 회원탈퇴
### 변경 사항
* 멤버 조회시 탈퇴한 회원 알수 없음 표시([링크](https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile1.svg?alt=media&token=13ef5688-3e56-452d-9c63-763958427674))
* 회원 탈퇴 서비스 로직 변경([링크](https://github.com/depromeet/fairer-be/compare/feature/sign-out?expand=1#diff-bbef0076a11644fe74913e042c1fbf141f027cb7de8d784e0e4e3b4b42fd067aL363))
  * 반복형 집안일에 할당된 인원이 0명인 경우 집안일 반복 중단(링크)
  * 회원 탈퇴시 unique 제약을 피하기 위해 email에 unique postfix 업데이트 